### PR TITLE
feat: custom API_BASE_URL

### DIFF
--- a/liblistenbrainz/client.py
+++ b/liblistenbrainz/client.py
@@ -41,17 +41,18 @@ STATS_SUPPORTED_TIME_RANGES = (
 )
 
 
-API_BASE_URL = 'https://api.listenbrainz.org'
+
 
 class ListenBrainz:
 
-    def __init__(self):
+    def __init__(self, API_BASE_URL = 'https://api.listenbrainz.org'):
         self._auth_token = None
 
         # initialize rate limit variables with None
         self._last_request_ts = None
         self.remaining_requests = None
         self.ratelimit_reset_in = None
+        self._API_BASE_URL = API_BASE_URL
 
 
     def _require_auth_token(self):
@@ -105,7 +106,7 @@ class ListenBrainz:
         try:
             self._wait_until_rate_limit()
             response = session.get(
-                urljoin(API_BASE_URL, endpoint),
+                urljoin(self._API_BASE_URL, endpoint),
                 params=params,
                 headers=headers,
             )
@@ -139,7 +140,7 @@ class ListenBrainz:
         try:
             self._wait_until_rate_limit()
             response = session.post(
-                urljoin(API_BASE_URL, endpoint),
+                urljoin(self._API_BASE_URL, endpoint),
                 data=data,
                 headers=headers,
             )

--- a/liblistenbrainz/client.py
+++ b/liblistenbrainz/client.py
@@ -45,14 +45,14 @@ STATS_SUPPORTED_TIME_RANGES = (
 
 class ListenBrainz:
 
-    def __init__(self, API_BASE_URL = 'https://api.listenbrainz.org'):
+    def __init__(self, api_base_url = 'https://api.listenbrainz.org'):
         self._auth_token = None
 
         # initialize rate limit variables with None
         self._last_request_ts = None
         self.remaining_requests = None
         self.ratelimit_reset_in = None
-        self._API_BASE_URL = API_BASE_URL
+        self.api_base_url = api_base_url
 
 
     def _require_auth_token(self):
@@ -106,7 +106,7 @@ class ListenBrainz:
         try:
             self._wait_until_rate_limit()
             response = session.get(
-                urljoin(self._API_BASE_URL, endpoint),
+                urljoin(self.api_base_url, endpoint),
                 params=params,
                 headers=headers,
             )
@@ -140,7 +140,7 @@ class ListenBrainz:
         try:
             self._wait_until_rate_limit()
             response = session.post(
-                urljoin(self._API_BASE_URL, endpoint),
+                urljoin(self.api_base_url, endpoint),
                 data=data,
                 headers=headers,
             )


### PR DESCRIPTION
`liblistenbrainz` is used in downstream projects to support scrobbling to listenbrainz. However, one limitation is that `liblistenbrainz` hardcodes `API_BASE_URL`. It would be great to allow specification of other API endpoints so that `liblistenbrainz` could scrobble to self-hosted, listenbrainz complaint APIs like [Maloja](https://github.com/krateng/maloja) and [Koito](https://github.com/gabehf/Koito). 

This PR is a simple change that allows `API_BASE_URL` to be changed when the client is initialized while retaining the default assignment `API_BASE_URL='https://api.listenbrainz.org'`.